### PR TITLE
Fix/export gltf animation correctly

### DIFF
--- a/Core/Scripts/Format/glTFAnimation.cs
+++ b/Core/Scripts/Format/glTFAnimation.cs
@@ -27,6 +27,7 @@ namespace UniGLTF
         public const string PATH_ROTATION = "rotation";
         public const string PATH_SCALE = "scale";
         public const string PATH_WEIGHT = "weights";
+        public const string NOT_IMPLEMENTED = "NotImplemented";
 
         public static int GetElementCount(string target)
         {

--- a/Core/Scripts/IO/gltfExporter.cs
+++ b/Core/Scripts/IO/gltfExporter.cs
@@ -275,7 +275,7 @@ namespace UniGLTF
             }
             else
             {
-                throw new NotImplementedException(property);
+                return glTFAnimationTarget.NOT_IMPLEMENTED;
             }
         }
 
@@ -329,6 +329,9 @@ namespace UniGLTF
 
                 var nodeIndex = GetNodeIndex(root, nodes, binding.path);
                 var target = PropertyToTarget(binding.propertyName);
+                if (target == glTFAnimationTarget.NOT_IMPLEMENTED) {
+                    continue;
+                }
                 var samplerIndex = animation.Animation.AddChannelAndGetSampler(nodeIndex, target);
                 var sampler = animation.Animation.samplers[samplerIndex];
 

--- a/Core/Scripts/IO/gltfExporter.cs
+++ b/Core/Scripts/IO/gltfExporter.cs
@@ -350,7 +350,14 @@ namespace UniGLTF
                 for (int i = 0; i < keys.Length; ++i, j += elementCount)
                 {
                     values.Input[i] = keys[i].time;
-                    values.Output[j] = keys[i].value;
+                    if (binding.propertyName == "m_LocalPosition.z" ||
+                        binding.propertyName == "m_LocalRotation.z" ||
+                        binding.propertyName == "m_LocalRotation.w")
+                    {
+                        values.Output[j] = -keys[i].value;
+                    } else {
+                        values.Output[j] = keys[i].value;
+                    }
                 }
             }
 


### PR DESCRIPTION
This is a pull request related to https://github.com/ousttrue/UniGLTF/issues/2 .

After that. I tweaked UniGLTF source code ( at f33c5fc ) and succeeded to export skeletal animation (unitychan model).

But, the result was broken. (Though This image is rendered by a WebGL Library I developed, I believe my implementation is correct.)

![2018-05-17 0 41 54](https://user-images.githubusercontent.com/3821214/40128199-00f1483e-596c-11e8-91ff-264245af61ea.jpg)

After trial and error, I understood that the conversion of animation data from left-handed system to right-handed system was missing.

This pull request fixes that point ( at a610bd3 ) . Then the result become OK.

![2018-05-17 0 31 37](https://user-images.githubusercontent.com/3821214/40128387-71e1a520-596c-11e8-95fd-c6e2285e2c94.jpg)

If it does not matter, I'd be happy if you could merge.
