### PR TITLE
Fix JSON writing and parsing with other locales

### DIFF
--- a/Core/JsonTool/JsonFormatter.cs
+++ b/Core/JsonTool/JsonFormatter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 using System.Linq.Expressions;
+using System.Globalization;
 
 namespace UniGLTF
 {
@@ -239,12 +240,12 @@ namespace UniGLTF
         public void Value(Single x)
         {
             CommaCheck();
-            m_w.Write(x.ToString("R"));
+            m_w.Write(x.ToString("R", CultureInfo.InvariantCulture));
         }
         public void Value(Double x)
         {
             CommaCheck();
-            m_w.Write(x.ToString("R"));
+            m_w.Write(x.ToString("R", CultureInfo.InvariantCulture));
         }
         public void Value(Vector3 v)
         {

--- a/Core/JsonTool/JsonParser.cs
+++ b/Core/JsonTool/JsonParser.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using System.Globalization;
 
 /// <summary>
 /// reference: http://www.json.org/index.html
@@ -325,12 +326,12 @@ namespace UniGLTF
         public float GetSingle()
         {
             if (JsonValueType != JsonValueType.Number) throw new JsonValueException("is not number: " + m_segment);
-            return float.Parse(m_segment.ToString());
+            return float.Parse(m_segment.ToString(), CultureInfo.InvariantCulture);
         }
         public double GetDouble()
         {
             if (JsonValueType != JsonValueType.Number) throw new JsonValueException("is not number: " + m_segment);
-            return double.Parse(m_segment.ToString());
+            return double.Parse(m_segment.ToString(), CultureInfo.InvariantCulture);
         }
         public string GetString()
         {


### PR DESCRIPTION
Certain locales use different characters to separate decimals in
floating point numbers. This can lead to invalid JSON files being
generated when the decimals are separated by a comma. To fix this,
an invariant locale should be used for writing and parsing floating
point numbers.

This issue was originally noticed by @Deatrathias (Virtual_Deat on
Twitter), who also came up with a way to solve it. This commit is based
on his solution.