### PR TITLE
Publicized PreExport method of PreShaderPropExporter class

### DIFF
--- a/Core/Scripts/IO/ShaderPropExporter/PreShaderPropExporter.cs
+++ b/Core/Scripts/IO/ShaderPropExporter/PreShaderPropExporter.cs
@@ -40,7 +40,7 @@ namespace UniGLTF.ShaderPropExporter
 
 #if UNITY_EDITOR
         [MenuItem(UniGLTFVersion.UNIGLTF_VERSION + "/PreExport ShaderProps")]
-        static void PreExport()
+        public static void PreExport()
         {
             foreach (var fi in typeof(PreShaderPropExporter).GetFields(
                 BindingFlags.Static 


### PR DESCRIPTION
The method is useful for build automation. I submit this pull request, considering such automation would be a common scenario for cases where the pre-exporting feature is utilized.